### PR TITLE
🚨 Fix "npx autocannon-ui"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .vscode/
 .idea/
 .nyc_output/

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "packages/autocannon-ui-backend/routes",
     "packages/autocannon-ui-backend/services",
     "packages/autocannon-ui-backend/index.js",
-    "packages/autocannon-ui-backend/package.json"
+    "packages/autocannon-ui-backend/package.json",
+    "packages/autocannon-compare-cli/lib.js",
+    "packages/autocannon-compare-cli/util.js",
+    "packages/autocannon-compare-cli/package.json"
   ],
   "scripts": {
     "build": "npm run build --workspaces --if-present",

--- a/packages/autocannon-ui-backend/routes/compare-v2.js
+++ b/packages/autocannon-ui-backend/routes/compare-v2.js
@@ -1,6 +1,5 @@
 import S from 'fluent-json-schema'
-
-import { compareResults } from '../../autocannon-compare-cli/lib.js'
+import { compareResults } from 'autocannon-compare-cli/lib.js'
 
 const autocannonModel = S.object()
   .required()


### PR DESCRIPTION
### Description

FIxes #816 

Looks like the `bin` command was broken with the changes introduced in 2.1.0 due to how `autocannon-compare-cli` package is being used.

<img width="987" alt="image" src="https://user-images.githubusercontent.com/12282640/227642503-4d70e99a-660d-4de3-b34a-13973087a674.png">

### Steps to replicate

Run `npx autocannon-ui`!

Also, run `npm pack` in the repo, then unpack the tarball and run `cli.js`.  You can test my fix this way as well 🙂 

I discovered `autocannon` a while ago, really love it, and just found this repo which is actually really helpful for `autocannon` users, nice work! ❤️ 