### PR TITLE
Allow port/host binding for cli

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,13 +7,5 @@
   "parserOptions": {
     "ecmaVersion": 2021,
     "sourceType": "module"
-  },
-  "rules" : {
-    "prettier/prettier": [
-      "error",
-      {
-        "endOfLine": "auto"
-      }
-    ]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,5 +7,13 @@
   "parserOptions": {
     "ecmaVersion": 2021,
     "sourceType": "module"
+  },
+  "rules" : {
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "semi": false,
   "singleQuote": true,
   "arrowParens": "avoid",
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "endOfLine": "lf"
 }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ The easiest way to try this out is to run:
 
 - a new browser window will be opened automatically
 
+You can also provide port or host parameter to listen on port/host of your choice.
+
+```sh
+npx autocannon-ui --help
+
+Usage: autocannon-ui [options]
+
+Options:
+  -p, --port <port>  listening port
+  -h, --host <host>  host to bind (default: "localhost")
+  --help             display help for command
+```
+
+- In some containers like podman, you need to pass host as '0.0.0.0' to listen on all available interfaces. For more information please check this [link](https://fastify.dev/docs/latest/Reference/Server/#listentextresolver).
+
 ## Development
 
 To easily develop the packages of this repo you can execute:

--- a/index.js
+++ b/index.js
@@ -49,12 +49,7 @@ async function startServer() {
     root: uiRoot
   })
 
-  let address = ""
-  if (options.port || options.host) {
-    address = await fastify.listen({port: options.port, host: options.host})
-  } else {
-    address = await fastify.listen()
-  }
+  const address = await fastify.listen({port: options.port, host: options.host})
   await fastify.ready()
 
   const start =

--- a/index.js
+++ b/index.js
@@ -3,9 +3,16 @@ import pino from 'pino'
 import Fastify from 'fastify'
 import fastifyStatic from '@fastify/static'
 import child_process from 'child_process'
+import { program } from 'commander'
 import { fileURLToPath } from 'url'
 import autocannonUiBackend from './packages/autocannon-ui-backend/index.js'
 
+program
+  .option("-p, --port <port>", "listening port")
+  .option("-h, --host <host>", "host to bind", "localhost")
+  .parse();
+
+const options = program.opts();
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
@@ -42,15 +49,20 @@ async function startServer() {
     root: uiRoot
   })
 
-  const address = await fastify.listen()
+  let address = ""
+  if (options.port || options.host) {
+    address = await fastify.listen({port: options.port, host: options.host})
+  } else {
+    address = await fastify.listen()
+  }
   await fastify.ready()
 
   const start =
     process.platform == 'darwin'
       ? 'open'
       : process.platform == 'win32'
-      ? 'start'
-      : 'xdg-open'
+        ? 'start'
+        : 'xdg-open'
 
   child_process.exec(start + ' ' + address)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@fastify/static": "^6.5.0",
         "autocannon": "^7.2.0",
         "autocannon-compare": "^0.4.0",
+        "commander": "^11.0.0",
         "concurrently": "^8.0.1",
         "env-schema": "^5.0.0",
         "fastify": "^4.0.2",
@@ -5829,7 +5830,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
       "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
-      "dev": true,
       "engines": {
         "node": ">=16"
       }
@@ -23288,8 +23288,7 @@
     "commander": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
-      "dev": true
+      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ=="
     },
     "commist": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -39,16 +39,17 @@
   "dependencies": {
     "@fastify/cors": "^8.0.0",
     "@fastify/static": "^6.5.0",
-    "autocannon-compare": "^0.4.0",
     "autocannon": "^7.2.0",
+    "autocannon-compare": "^0.4.0",
+    "commander": "^11.0.0",
     "concurrently": "^8.0.1",
     "env-schema": "^5.0.0",
+    "fastify": "^4.0.2",
     "fastify-cli": "^5.0.0",
     "fastify-plugin": "^4.0.0",
-    "fastify": "^4.0.2",
     "fluent-json-schema": "^4.0.0",
-    "pino-pretty": "^10.0.0",
-    "pino": "^8.0.0"
+    "pino": "^8.0.0",
+    "pino-pretty": "^10.0.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.19.1",


### PR DESCRIPTION
Fixes: https://github.com/nearform/autocannon-ui/issues/1077

**Description**
This PR enables user to pass **port** or **host** parameters for running with cli (i.e. **npx autocannon-ui**). It should accept all patterns valid for [fasitfy](https://fastify.dev/docs/latest/Reference/Server/#listentextresolver)

**Options**

- **-p** or **--port** 

![image](https://github.com/nearform/autocannon-ui/assets/182440/74a328af-6d84-432e-8a4a-d65c33223f5c)

- **-h** or **--host**

![image](https://github.com/nearform/autocannon-ui/assets/182440/0f9957cd-c566-4083-b5d1-123e67558576)

