### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit ${1}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged && npm run toc && git add README.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@babel/preset-react": "^7.18.6",
         "@commitlint/cli": "^19.0.3",
         "@commitlint/config-conventional": "^18.0.0",
-        "husky": "^9.0.6",
+        "husky": "^9.0.11",
         "lint-staged": "^15.0.1",
         "markdown-toc": "^1.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@babel/preset-react": "^7.18.6",
     "@commitlint/cli": "^19.0.3",
     "@commitlint/config-conventional": "^18.0.0",
-    "husky": "^9.0.6",
+    "husky": "^9.0.11",
     "lint-staged": "^15.0.1",
     "markdown-toc": "^1.2.0"
   },


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)